### PR TITLE
yeah, ensure_chanhead_is_ready could leave the chanhead in an INACTIV…

### DIFF
--- a/src/store/memory/store.c
+++ b/src/store/memory/store.c
@@ -780,7 +780,6 @@ ngx_int_t memstore_ensure_chanhead_is_ready(nchan_store_channel_head_t *head, ui
       memstore_ready_chanhead_unless_stub(head);
     }
   }
-  assert(head->status != INACTIVE);
   return NGX_OK;
 }
 


### PR DESCRIPTION
…E state. get rid of this overzealous assert